### PR TITLE
Remove hard coded api url

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,0 @@
-VUE_APP_API_FILES_ENPOINT = 'http://localhost:8080/api/files'
-VUE_APP_APP_KEY = 'a51cc72f1f2e062e428f'
-VUE_APP_ISSUES_EVENT = 'parsed-file'

--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+VUE_APP_API_FILES_ENPOINT = 'http://localhost:8080/api/files'
+VUE_APP_APP_KEY = 'a51cc72f1f2e062e428f'
+VUE_APP_ISSUES_EVENT = 'parsed-file'

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+VUE_APP_API_FILES_ENPOINT = 'http://localhost:8080/api/files'
+VUE_APP_APP_KEY = 'a51cc72f1f2e062e428f'
+VUE_APP_ISSUES_EVENT = 'parsed-file'

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 
 
 # local env files
+.env
 .env.local
 .env.*.local
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -32,9 +32,9 @@
 
     Pusher.logToConsole = true
 
-    const API_FILES_ENPOINT = 'http://localhost:8080/api/files'
-    const APP_KEY = 'a51cc72f1f2e062e428f'
-    const ISSUES_EVENT = 'parsed-file'
+    const API_FILES_ENPOINT = process.env.VUE_APP_API_FILES_ENPOINT
+    const APP_KEY = process.env.VUE_APP_APP_KEY
+    const ISSUES_EVENT = process.env.VUE_APP_ISSUES_EVENT
 
     const pusher = new Pusher(APP_KEY, {
         cluster: 'eu'
@@ -121,6 +121,7 @@
                     })
                 } catch (error) {
                     this.error = 'Error loading issues'
+                    console.log(this.error)
                 } finally {
                     this.isLoading = false
                 }


### PR DESCRIPTION
Changed to used .env variable and also created an example, but I have doubts.
Should the information be in the example? Feels like it defeats the purpose of not having it hard coded.